### PR TITLE
Fix widget manager issue for when we have multiple sessions opened

### DIFF
--- a/src/viewPanel/sessionWidget.ts
+++ b/src/viewPanel/sessionWidget.ts
@@ -24,7 +24,7 @@ export class SessionWidget extends BoxPanel {
     this.addClass('grid-panel');
 
     this._model = options.model;
-    this._rendermime = options.rendermime;
+    this._rendermime = options.rendermime.clone();
     this._notebookTracker = options.notebookTracker;
     this._context = options.context;
     this._commands = options.commands;


### PR DESCRIPTION
Sharing the same rendermime object between sessions would make the widget renderers share the same widget manager instead of one per-session