### PR TITLE
Refactor the selected attributes and dataset

### DIFF
--- a/src/linkPanel/model.ts
+++ b/src/linkPanel/model.ts
@@ -8,7 +8,6 @@ import {
   ILinkEditorModel,
   IAdvLinkCategories,
   IAdvLinkDescription,
-  IDatasets,
   ComponentLinkType,
   IdentityLinkFunction
 } from './types';
@@ -25,11 +24,6 @@ export class LinkEditorModel implements ILinkEditorModel {
     this._sharedModel.linksChanged.connect(this.onLinksChanged, this);
     this._sharedModel.datasetChanged.connect(this.onDatasetsChanged, this);
     this._getAdvancedLinksCategories();
-
-    this._currentDatasets = {
-      first: '',
-      second: ''
-    };
   }
 
   get sharedModel(): IGlueSessionSharedModel {
@@ -39,10 +33,10 @@ export class LinkEditorModel implements ILinkEditorModel {
   /**
    * Getter and setter for datasets.
    */
-  get currentDatasets(): IDatasets {
+  get currentDatasets(): [string, string] {
     return this._currentDatasets;
   }
-  set currentDatasets(datasets: IDatasets) {
+  set currentDatasets(datasets: [string, string]) {
     this._currentDatasets = datasets;
     this._datasetsChanged.emit(this._currentDatasets);
   }
@@ -50,15 +44,15 @@ export class LinkEditorModel implements ILinkEditorModel {
   /**
    * Replace one current dataset.
    */
-  setCurrentDataset(position: keyof IDatasets, value: string): void {
-    this._currentDatasets[position] = value;
+  setCurrentDataset(index: number, value: string): void {
+    this._currentDatasets[index] = value;
     this._datasetsChanged.emit(this._currentDatasets);
   }
 
   /**
    * A signal emits when current datasets changes
    */
-  get currentDatasetsChanged(): ISignal<this, IDatasets> {
+  get currentDatasetsChanged(): ISignal<this, [string, string]> {
     return this._datasetsChanged;
   }
 
@@ -133,10 +127,10 @@ export class LinkEditorModel implements ILinkEditorModel {
     // Reset the current dataset, with empty values if there is less than 2 datasets.
     if (this._sharedModel.dataset) {
       const datasetsList = Object.keys(this._sharedModel.dataset);
-      this._currentDatasets = {
-        first: datasetsList.length > 1 ? datasetsList[0] : '',
-        second: datasetsList.length > 1 ? datasetsList[1] : ''
-      };
+      this._currentDatasets = [
+        datasetsList.length > 1 ? datasetsList[0] : '',
+        datasetsList.length > 1 ? datasetsList[1] : ''
+      ];
       this._datasetsChanged.emit(this._currentDatasets);
     }
   }
@@ -164,8 +158,8 @@ export class LinkEditorModel implements ILinkEditorModel {
   }
 
   private _sharedModel: IGlueSessionSharedModel;
-  private _currentDatasets: IDatasets;
-  private _datasetsChanged = new Signal<this, IDatasets>(this);
+  private _currentDatasets: [string, string] = ['', ''];
+  private _datasetsChanged = new Signal<this, [string, string]>(this);
   private _advLinksPromise = new PromiseDelegate<IAdvLinkCategories>();
   private _advLinkCategories: IAdvLinkCategories = {};
   private _identityLinks = new Map<string, ILink>();

--- a/src/linkPanel/types.ts
+++ b/src/linkPanel/types.ts
@@ -12,14 +12,13 @@ export const IdentityLinkUsing = {
   function: IdentityLinkFunction
 };
 
-export const IDatasetsKeys = ['first', 'second'] as (keyof IDatasets)[];
 /**
  * The link editor model.
  */
 export interface ILinkEditorModel {
-  currentDatasets: IDatasets;
-  setCurrentDataset(position: keyof IDatasets, value: string): void;
-  readonly currentDatasetsChanged: ISignal<this, IDatasets>;
+  currentDatasets: [string, string];
+  setCurrentDataset(index: number, value: string): void;
+  readonly currentDatasetsChanged: ISignal<this, [string, string]>;
   readonly identityLinks: Map<string, ILink>;
   readonly advancedLinks: Map<string, ILink>;
   readonly linksChanged: ISignal<this, void>;
@@ -45,12 +44,4 @@ export interface IAdvLinkDescription {
  */
 export interface IAdvLinkCategories {
   [category: string]: IAdvLinkDescription[];
-}
-
-/**
- * Definition of the selected datasets.
- */
-export interface IDatasets {
-  first: string;
-  second: string;
 }

--- a/src/linkPanel/widgets/summary.tsx
+++ b/src/linkPanel/widgets/summary.tsx
@@ -14,7 +14,7 @@ import {
 import * as React from 'react';
 
 import { LinkEditorWidget } from '../linkEditorWidget';
-import { IDatasets, ILink, ILinkEditorModel } from '../types';
+import { ILink } from '../types';
 
 /**
  * The widget displaying the links for the selected dataset.
@@ -43,7 +43,7 @@ export class Summary extends LinkEditorWidget {
     this._linkEditorModel.linksChanged.connect(this.linksChanged, this);
 
     if (this._linkEditorModel.currentDatasets) {
-      this.updateLinks(this._linkEditorModel.currentDatasets);
+      this.updateLinks();
     }
   }
 
@@ -51,19 +51,19 @@ export class Summary extends LinkEditorWidget {
    * Triggered when links has changed.
    */
   linksChanged(): void {
-    this.updateLinks(this._linkEditorModel.currentDatasets);
+    this.updateLinks();
   }
   /**
    * Callback when the selected datasets change.
    */
-  onDatasetsChange(_sender: ILinkEditorModel, datasets: IDatasets): void {
-    this.updateLinks(datasets);
+  onDatasetsChange(): void {
+    this.updateLinks();
   }
 
   /**
    * Updates the list of links when the selected dataset changes.
    */
-  updateLinks(dataset: IDatasets): void {
+  updateLinks(): void {
     const datasetLinks = new Map<string, Private.ISummaryLink[]>();
 
     // Remove all the existing widgets.


### PR DESCRIPTION
Simplify implementation by removing concept of 'first' and 'second' on selected attributes and dataset.

The idea is to remove the concept of `IDatasets` and `ISelectedIdentityAttributes` (objects with `first` and `second` keys), to replace them by simple array.

Currently the datasets and attributes widgets in `Linking` panel are array of 2 elements while the selected dataset and attributes are objects.
This PR homogenize that by using only array of 2 elements.