### PR TITLE
Fix advanced links

### DIFF
--- a/gluepyter/glue_ydoc.py
+++ b/gluepyter/glue_ydoc.py
@@ -251,7 +251,7 @@ class YGlue(YBaseDoc):
                     list_name = f"list{'' if lists_count < 0 else f'_{lists_count}'}"
                     lists_count += 1
                     link.pop(f"cids{i}_labels", None)
-                    link.pop(f"data{i}", None)
+                    link[f"data{i}"] = link.pop(f"data{i}", None)
                     attr_list = {
                         "_type": "builtins.list",
                         "contents": link.pop(f"cids{i}", []),

--- a/gluepyter/glue_ydoc.py
+++ b/gluepyter/glue_ydoc.py
@@ -251,7 +251,6 @@ class YGlue(YBaseDoc):
                     list_name = f"list{'' if lists_count < 0 else f'_{lists_count}'}"
                     lists_count += 1
                     link.pop(f"cids{i}_labels", None)
-                    link[f"data{i}"] = link.pop(f"data{i}", None)
                     attr_list = {
                         "_type": "builtins.list",
                         "contents": link.pop(f"cids{i}", []),

--- a/src/linkPanel/linkEditor.ts
+++ b/src/linkPanel/linkEditor.ts
@@ -60,7 +60,7 @@ export class LinkEditor extends BoxPanel {
     );
     maxHeight = Math.max(
       ...headers.map(
-        header => (header?.node.firstChild as HTMLElement).offsetHeight || 0
+        header => (header?.node.firstChild as HTMLElement)?.offsetHeight || 0
       )
     );
     headers.forEach(header => {


### PR DESCRIPTION
This PR fix 2 issues:
- the `data1` and `data2` attributes of the advanced links were not saved in the content, and so in the session file
- the computation of link panel headers was sometime raising because the header has no child