### PR TITLE
Add data without session corruption

### DIFF
--- a/gluepyter/glue_session.py
+++ b/gluepyter/glue_session.py
@@ -368,7 +368,7 @@ class SharedGlueSession:
         serialized_data = [
             (previous_data_serializer.id(obj), previous_data_serializer.do(obj))
             for oid, obj in list(data_serializer._objs.items())
-            ]
+        ]
         serialized_data = dict(serialized_data)
 
         contents = self._document.contents

--- a/gluepyter/glue_utils.py
+++ b/gluepyter/glue_utils.py
@@ -10,6 +10,17 @@ from ipywidgets import HTML
 load_plugins()
 
 
+class ErrorWidget:
+    """Wrapper of a HTML widget for showing error message"""
+
+    def __init__(self, e: Exception, path: str) -> None:
+        value = f"{type(e).__name__} at line {e.__traceback__.tb_lineno} of {path}: {e}"
+        self._widget = HTML(value=value)
+
+    def show(self):
+        display(self._widget)
+
+
 def get_function_info(function_or_helper):
     item_info: Dict[str, Dict] = {}
     attributes = ["description", "labels1", "labels2", "display"]
@@ -67,12 +78,31 @@ def get_advanced_links():
     return advanced_links
 
 
-class ErrorWidget:
-    """Wrapper of a HTML widget for showing error message"""
-
-    def __init__(self, e: Exception, path: str) -> None:
-        value = f"{type(e).__name__} at line {e.__traceback__.tb_lineno} of {path}: {e}"
-        self._widget = HTML(value=value)
-
-    def show(self):
-        display(self._widget)
+def nested_compare(value1, value2):
+    # Compare lists
+    if isinstance(value1, list):
+        if isinstance(value2, list):
+            if len(value1) == len(value2):
+                for v1, v2 in zip(value1, value2):
+                    if not nested_compare(v1, v2):
+                        return False
+                return True
+            else:
+                return False
+        else:
+            return False
+    # Compare dict
+    if isinstance(value1, dict):
+        if isinstance(value2, dict):
+            for k1, v1 in value1.items():
+                if k1 in value2.keys():
+                    if not nested_compare(v1, value2[k1]):
+                        return False
+                else:
+                    return False
+            return True
+        else:
+            return False
+    # Compare immutable
+    else:
+        return value1 == value2

--- a/gluepyter/glue_utils.py
+++ b/gluepyter/glue_utils.py
@@ -83,23 +83,23 @@ def nested_compare(value1, value2):
     if isinstance(value1, list) and isinstance(value2, list):
         if not len(value1) == len(value2):
             return False
-        
+
         for v1, v2 in zip(value1, value2):
             if not nested_compare(v1, v2):
                 return False
-        
+
         return True
 
     # Compare dict
     if isinstance(value1, dict) and isinstance(value2, dict):
         for k1, v1 in value1.items():
-            if not k1 in value2.keys():
+            if k1 not in value2.keys():
                 return False
-            
+
             if not nested_compare(v1, value2[k1]):
                 return False
-        
+
         return True
-    
+
     # Compare immutable
     return value1 == value2

--- a/gluepyter/glue_utils.py
+++ b/gluepyter/glue_utils.py
@@ -80,29 +80,26 @@ def get_advanced_links():
 
 def nested_compare(value1, value2):
     # Compare lists
-    if isinstance(value1, list):
-        if isinstance(value2, list):
-            if len(value1) == len(value2):
-                for v1, v2 in zip(value1, value2):
-                    if not nested_compare(v1, v2):
-                        return False
-                return True
-            else:
+    if isinstance(value1, list) and isinstance(value2, list):
+        if not len(value1) == len(value2):
+            return False
+        
+        for v1, v2 in zip(value1, value2):
+            if not nested_compare(v1, v2):
                 return False
-        else:
-            return False
+        
+        return True
+
     # Compare dict
-    if isinstance(value1, dict):
-        if isinstance(value2, dict):
-            for k1, v1 in value1.items():
-                if k1 in value2.keys():
-                    if not nested_compare(v1, value2[k1]):
-                        return False
-                else:
-                    return False
-            return True
-        else:
-            return False
+    if isinstance(value1, dict) and isinstance(value2, dict):
+        for k1, v1 in value1.items():
+            if not k1 in value2.keys():
+                return False
+            
+            if not nested_compare(v1, value2[k1]):
+                return False
+        
+        return True
+    
     # Compare immutable
-    else:
-        return value1 == value2
+    return value1 == value2

--- a/gluepyter/tests/test_glue_session.py
+++ b/gluepyter/tests/test_glue_session.py
@@ -1,8 +1,9 @@
 import y_py as Y
 from copy import deepcopy
 from pathlib import Path
-from gluepyter.glue_session import SharedGlueSession
 from ipywidgets import Output
+from gluepyter.glue_session import SharedGlueSession
+from gluepyter.glue_utils import nested_compare
 
 
 def test_init(session_path):
@@ -64,32 +65,6 @@ def test__read_view_state(yglue_session):
 
 
 def test_add_data(yglue_session):
-    def nested_compare(value1, value2):
-        if isinstance(value1, list):
-            if isinstance(value2, list):
-                if len(value1) == len(value2):
-                    for v1, v2 in zip(value1, value2):
-                        if not nested_compare(v1, v2):
-                            return False
-                    return True
-                else:
-                    return False
-            else:
-                return False
-        if isinstance(value1, dict):
-            if isinstance(value2, dict):
-                for k1, v1 in value1.items():
-                    if k1 in value2.keys():
-                        if not nested_compare(v1, value2[k1]):
-                            return False
-                    else:
-                        return False
-                return True
-            else:
-                return False
-        else:
-            return value1 == value2
-
     yglue_session._load_data()
     file_path = Path(__file__).parents[2] / "examples" / "w6_psc.vot"
 

--- a/gluepyter/tests/test_glue_session.py
+++ b/gluepyter/tests/test_glue_session.py
@@ -64,7 +64,6 @@ def test__read_view_state(yglue_session):
 
 
 def test_add_data(yglue_session):
-
     def nested_compare(value1, value2):
         if isinstance(value1, list):
             if isinstance(value2, list):
@@ -102,19 +101,19 @@ def test_add_data(yglue_session):
 
     # Assert there is no change in previous structure
     for key, value in contents.items():
-        if key == 'DataCollection':
+        if key == "DataCollection":
             continue
         assert key in updated_contents.keys()
         assert nested_compare(value, updated_contents[key])
 
     # Compare the DataCollection
-    for key, value in contents['DataCollection'].items():
-        if key == 'data' or key == 'cids' or key == 'components':
-            assert not nested_compare(value, updated_contents['DataCollection'][key])
+    for key, value in contents["DataCollection"].items():
+        if key == "data" or key == "cids" or key == "components":
+            assert not nested_compare(value, updated_contents["DataCollection"][key])
         else:
-            assert nested_compare(value, updated_contents['DataCollection'][key])
+            assert nested_compare(value, updated_contents["DataCollection"][key])
 
-    assert "w6_psc" in updated_contents['DataCollection']['data']
+    assert "w6_psc" in updated_contents["DataCollection"]["data"]
 
 
 def test_add_identity_link(yglue_session, identity_link):


### PR DESCRIPTION
This PR adds new data without corrupting the session file.

There were 2 ways to do this:
- serializing the new data in the context of the previous data, and include the generated data in the session content.
- serializing all the data (previous and new) and compare the generated one to the previous one to include only the new attributes.

I choose to implement the first way to avoid a comparison in nested dictionary (even if at first glance there should be no change in the nested data).
Nevertheless, it seems that the second way do not corrupt existing serialized data neither.